### PR TITLE
Change lower case letter "f" to capital "F" in facade alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Want to know more about how it works? check this following [link](https://medium
 Amranidev\Laracombee\Providers\LaracombeeServiceProvider::class,
 
 // Alias.
-'Laracombee' => Amranidev\Laracombee\facades\LaracombeeFacade::class,
+'Laracombee' => Amranidev\Laracombee\Facades\LaracombeeFacade::class,
 ```
 
  3. Create a new instance in [recombee.com](https://www.recombee.com/)


### PR DESCRIPTION
This PR should fix the problem described in issue #47. The Facades directory and namespace uses a capital "F" in its name but the example in the README file uses a lower case "f" for the facade alias. This will result in the class not being found in Linux and other case-sensitive systems (Windows is mostly case-insensitive so it will probably work in Windows but break when uploaded to a Linux-server). 